### PR TITLE
Move `DefaultTheme` declaration to a separate folder, remove unused types

### DIFF
--- a/declarations/styled-components.d.ts
+++ b/declarations/styled-components.d.ts
@@ -1,0 +1,8 @@
+import "styled-components";
+
+// https://styled-components.com/docs/api#create-a-declarations-file
+declare module "styled-components" {
+  export interface DefaultTheme {
+    fontFamily: string;
+  }
+}

--- a/src/styles/default-theme.ts
+++ b/src/styles/default-theme.ts
@@ -1,19 +1,5 @@
 import { DefaultTheme } from "styled-components";
 
-declare module "styled-components" {
-  export interface DefaultTheme {
-    fontFamily: string;
-  }
-}
-
-export interface Theme {
-  fontFamily: string;
-}
-
-export interface ThemeProps {
-  theme: Theme;
-}
-
 export const defaultTheme: DefaultTheme = {
   fontFamily:
     "Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif",


### PR DESCRIPTION
Moving external module declarations outside `src` makes type loading more predictable and less scattered across the codebase. We can keep placing new typings to `declarations/some-package.d.ts` and `declarations/@some-org/some-package.d.t` in the future. This applies to overrides like `styled-components` `DefaultTheme` or to package without any declarations available.

Relevant docs: https://styled-components.com/docs/api#typescript

Follows #15