### PR TITLE
Configure context-based env vars

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,12 +9,12 @@
  * map PROD_XYZ / XYZ_PROD or PR_XYZ / XYZ_PR into XYZ.
  */
 
-const suffixOrPrefix =
-  process.env.CONTEXT === "production"
-    ? "PROD"
-    : process.env.CONTEXT === "deploy-preview"
-    ? "PR"
-    : "";
+const suffixOrPrefixByContext = {
+  production: "PROD",
+  "deploy-preview": "PR",
+};
+
+const suffixOrPrefix = suffixOrPrefixByContext[process.env.CONTEXT];
 
 if (suffixOrPrefix) {
   for (const key in process.env) {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,32 @@
 // @ts-check
 
+/*
+ * Netlify UI does not support context-based environment variables.
+ * For example, we cannot configure XYZ=42 for preview releases (pull requests)
+ * and XYZ=4242 for production (main branch).
+ *
+ * As a workaround, we read Netlify’s CONTEXT env variable and then
+ * map PROD_XYZ / XYZ_PROD or PR_XYZ / XYZ_PR into XYZ.
+ */
+
+const suffixOrPrefix =
+  process.env.CONTEXT === "production"
+    ? "PROD"
+    : process.env.CONTEXT === "deploy-preview"
+    ? "PR"
+    : "";
+
+if (suffixOrPrefix) {
+  for (const key in process.env) {
+    if (key.startsWith(`${suffixOrPrefix}_`)) {
+      process.env[key.slice(suffixOrPrefix.length + 1)] = process.env[key];
+    } else if (key.endsWith(`_${suffixOrPrefix}`)) {
+      process.env[key.slice(undefined, suffixOrPrefix.length - 1)] =
+        process.env[key];
+    }
+  }
+}
+
 /**
  * @type import("next").NextConfig
  */


### PR DESCRIPTION
Netlify UI does not support context-based environment variables. For example, we cannot configure `XYZ=42` for preview releases (pull requests) and `XYZ=4242` for production (main branch).

As a workaround, we read Netlify’s `CONTEXT` env variable and then map `PROD_XYZ` / `XYZ_PROD` or `PR_XYZ` / `XYZ_PR` into `XYZ`.

`next.config.js` runs before the rest of the app code, so our workaround applies everywhere.

### Prior art

- https://www.npmjs.com/package/netlify-plugin-contextual-env
   - [no updates for two years](https://www.npmjs.com/package/netlify-plugin-contextual-env?activeTab=versions)
   - [exposes secrets in build logs](https://github.com/cball/netlify-plugin-contextual-env/issues/19)
   - [does not support env mapping in runtime](https://github.com/cball/netlify-plugin-contextual-env/issues/6)
   
- https://answers.netlify.com/t/environment-variable-contexts-not-working/45701/3
   - does not allow to store secrets