### PR TITLE
Improve error handling when loading Y.Maps

### DIFF
--- a/src/components/inherited-map/components/map/map.js
+++ b/src/components/inherited-map/components/map/map.js
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { observer } from "mobx-react";
 import * as React from "react";
 import styled from "styled-components";
@@ -81,6 +82,14 @@ export const Map = observer(() => {
   }, [mapStore, boundsChangeHandler]);
 
   const mapRef = React.useRef();
+
+  React.useEffect(() => {
+    if (!window.ymaps) {
+      Sentry.captureException(
+        new Error("Map was not rendered because window.ymaps is undefined"),
+      );
+    }
+  }, []);
 
   if (!window.ymaps) {
     return (

--- a/src/components/inherited-map/components/map/map.js
+++ b/src/components/inherited-map/components/map/map.js
@@ -1,9 +1,20 @@
 import { observer } from "mobx-react";
 import * as React from "react";
+import styled from "styled-components";
 
 import { useStore } from "../../models/root-store";
 import { StyledMap } from "./styles";
 // import { debounce } from 'utils'
+
+const ErrorMessage = styled.div`
+  position: absolute;
+  bottom: 20px;
+  font-size: 1.5rem;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: red;
+`;
 
 export const Map = observer(() => {
   const { mapStore } = useStore();
@@ -22,6 +33,10 @@ export const Map = observer(() => {
     [mapStore],
   );
   React.useEffect(() => {
+    if (!window.ymaps) {
+      return;
+    }
+
     window.ymaps.ready(["Heatmap"]).then(() => {
       const { center, zoom } = mapStore;
       const map = new window.ymaps.Map(
@@ -66,6 +81,14 @@ export const Map = observer(() => {
   }, [mapStore, boundsChangeHandler]);
 
   const mapRef = React.useRef();
+
+  if (!window.ymaps) {
+    return (
+      <ErrorMessage>
+        Яндекс.Карты не загрузились. Попробуйте обновить страницу.
+      </ErrorMessage>
+    );
+  }
 
   return <StyledMap id="map" ref={mapRef} />;
 });


### PR DESCRIPTION
## Before (dev / prod)

<img width="716" alt="Screenshot 2022-01-29 at 10 43 47" src="https://user-images.githubusercontent.com/608862/151658144-ef14c15e-d64b-4137-bb3f-73fe0c955707.png">

<img width="714" alt="Screenshot 2022-01-29 at 10 43 58" src="https://user-images.githubusercontent.com/608862/151658147-f346043e-1f72-4830-be2e-ac1e0a45b0b8.png">


## After (dev & prod)
<img width="714" alt="Screenshot 2022-01-29 at 10 44 41" src="https://user-images.githubusercontent.com/608862/151658158-4bbb3c94-4caf-4a23-b2c0-e437f150c129.png">

---

If you want to test this change, you can block `api-maps.yandex.ru` in DevTools

<img width="418" alt="Screenshot 2022-01-29 at 10 50 08" src="https://user-images.githubusercontent.com/608862/151658241-b2d2e0b4-6197-4d9a-a731-34aa05457bf8.png">