### PR TITLE
Serve robots.txt

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 AUTH0_SCOPE=openid profile
 
 DJANGO_BASE_URL=https://dtp-stat.ru
+PRODUCTION_HOST=dtp-stat.ru

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,6 +36,15 @@ const nextConfig = {
       permanent: true,
     },
   ],
+
+  rewrites: () => ({
+    beforeFiles: [
+      {
+        source: "/robots.txt",
+        destination: "/api/rewrites/robots",
+      },
+    ],
+  }),
 };
 
 /**

--- a/src/pages/api/rewrites/robots.tsx
+++ b/src/pages/api/rewrites/robots.tsx
@@ -1,0 +1,33 @@
+import { withSentry } from "@sentry/nextjs";
+import { NextApiHandler, NextApiRequest } from "next";
+
+const robotsTxtInProduction = `
+User-agent: *
+Disallow: /admin
+Disallow: /api
+Disallow: /ckeditor
+Disallow: /board
+Disallow: /accounts
+`.trim();
+
+const robotsTxtElsewhere = `
+User-agent: *
+Disallow: /
+`.trim();
+
+const getRequestHost = (req: NextApiRequest): string | undefined =>
+  typeof req.headers["x-forwarded-host"] === "string"
+    ? req.headers["x-forwarded-host"]
+    : req.headers["host"];
+
+const hander: NextApiHandler = (req, res) => {
+  res.setHeader("Cache-Control", "private");
+  res.setHeader("Content-Type", "text/plain");
+  res.send(
+    getRequestHost(req) === process.env.PRODUCTION_HOST
+      ? robotsTxtInProduction
+      : robotsTxtElsewhere,
+  );
+};
+
+export default withSentry(hander);


### PR DESCRIPTION
This PR is similar to https://github.com/dtpstat/dtp-stat/pull/59 _(internal link)_

We serve `robots.txt` conditionally based on the current host header. This protects non-production website mirrors from indexing. The contents of both file versions are borrowed from Django. We can update them later once we’ve fully transitioned to Next.js.

Local tests with [HTTPie](https://httpie.io):

```shell
http http://localhost:3000/robots.txt --body
```

```text
User-agent: *
Disallow: /
```

---

```shell
http http://localhost:3000/robots.txt Host:dtp-stat.ru --body
```

```text
User-agent: *
Disallow: /admin
Disallow: /api
Disallow: /ckeditor
Disallow: /board
Disallow: /accounts
```

