### PR TITLE
Fix Django content fallback

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,7 +5,11 @@ import { withSentryConfig } from "@sentry/nextjs";
 // We don’t use the prefix outside Next.js code to make app setup less bulky and
 // to avoid unnecessary breaking changes in it.
 process.env.NEXT_PUBLIC_COMMENTS_ARE_PAUSED = process.env.COMMENTS_ARE_PAUSED;
+
 process.env.NEXT_PUBLIC_DJANGO_BASE_URL = process.env.DJANGO_BASE_URL;
+process.env.NEXT_PUBLIC_DJANGO_CONTENT_FALLBACK =
+  process.env.DJANGO_CONTENT_FALLBACK;
+
 process.env.NEXT_PUBLIC_SENTRY_DSN = process.env.SENTRY_DSN;
 process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT;
 
@@ -53,12 +57,18 @@ const nextConfig = {
       process.env.DJANGO_CONTENT_FALLBACK === "true"
         ? [
             {
-              // Add trailing slash to page urls (no .) to avoid infinite redirects
+              // Add trailing slash to page-like paths (/hello/world) to avoid infinite redirects
               source: "/:path([^\\.]+)*",
               destination: `${process.env.DJANGO_BASE_URL}/:path*/`,
             },
             {
-              // Do not add trailing slash to files to avoid 404
+              // Add trailing slash to root file-like paths (/hello.txt), also to avoid infinite
+              // redirects (this is needed because of a special `old_redirect` rule in Django)
+              source: "/:path",
+              destination: `${process.env.DJANGO_BASE_URL}/:path/`,
+            },
+            {
+              // Do not add trailing slash to all other file-like paths (/hello/world.txt)
               source: "/:path*",
               destination: `${process.env.DJANGO_BASE_URL}/:path*`,
             },

--- a/src/components/inherited-map/components/info-balloon.tsx
+++ b/src/components/inherited-map/components/info-balloon.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 
-import { djangoBaseUrl } from "../../../shared/django-helpers";
+import {
+  djangoBaseUrl,
+  djangoContentFallback,
+} from "../../../shared/django-helpers";
 import { Colors } from "../../../styles/colors";
 import SvgIcon from "./svg-icon";
 
@@ -62,7 +65,7 @@ export const InfoBalloonContent = (props: Props) => {
         <a
           id="balloon-button"
           className="btn-light"
-          href={`${djangoBaseUrl}/dtp/${props.id}`}
+          href={`${djangoContentFallback ? "" : djangoBaseUrl}/dtp/${props.id}`}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/shared/django-helpers.tsx
+++ b/src/shared/django-helpers.tsx
@@ -13,6 +13,8 @@ import * as React from "react";
 import { Link } from "../components/link";
 
 export const djangoBaseUrl = process.env.NEXT_PUBLIC_DJANGO_BASE_URL ?? "";
+export const djangoContentFallback =
+  process.env.NEXT_PUBLIC_DJANGO_CONTENT_FALLBACK === "true";
 
 const postMessageToIframeParent = (message: unknown): boolean => {
   if (window !== window.parent) {


### PR DESCRIPTION
This PR follows #28

When playing with https://dtp-stat-on-nextjs.netlify.app, I noticed that going to `/robots2.txt` was trigging an infinite redirect: `/robots2.txt` ←→ `/robots2.txt/`. This only applied to root files, i.e. `/path/robots2.txt` was working OK.

After some digging, I found a redirect rule on the Django side which was causing this edge-case behavior. It only applied to root paths:

- https://github.com/dtpstat/dtp-stat/blob/104072e8ccd064880bad83c106daa2049f64ad2f/dtpstat/urls.py#L58
- https://github.com/dtpstat/dtp-stat/blob/104072e8ccd064880bad83c106daa2049f64ad2f/application/views.py#L227-L228

(internal links)

Adding a new rewrite rule in `next.config.mjs`  fixed the problem.

---

Another thing I did was propagating `DJANGO_CONTENT_FALLBACK` into the front-end bundle. The new variable is called `djangoContentFallback`. It should help us with these balloon links:

<img width="394" alt="Screenshot 2022-02-01 at 23 13 01" src="https://user-images.githubusercontent.com/608862/152067331-32c7d78c-59bc-4072-9184-0adc717f6aba.png">

When `DJANGO_CONTENT_FALLBACK` is `true`, we want to open `{samesite}/dtp/[id]`. Otherwise, it is `{django}/dtp/[id]`. The latter will be needed if we enable the map before updating DNS records. The former is what we want to do afterwards.