### PR TITLE
Move `withApiAuthRequired` in comments API grant guest read access

### DIFF
--- a/src/pages/api/comments/[accident-id].ts
+++ b/src/pages/api/comments/[accident-id].ts
@@ -9,10 +9,12 @@ const handler: NextApiHandler = async (req, res) => {
   const accidentId = req.query["accident-id"] as string;
 
   if (req.method === "POST") {
-    const comment = await createComment(
-      JSON.parse(req.body as string) as NewComment,
-    );
-    res.status(200).json({ status: "ok", comment });
+    return withApiAuthRequired(async () => {
+      const comment = await createComment(
+        JSON.parse(req.body as string) as NewComment,
+      );
+      res.status(200).json({ status: "ok", comment });
+    })(req, res);
   } else if (req.method === "GET") {
     res
       .status(200)
@@ -25,4 +27,4 @@ const handler: NextApiHandler = async (req, res) => {
   }
 };
 
-export default withSentry(withApiAuthRequired(handler));
+export default withSentry(handler);


### PR DESCRIPTION
This PR fixes a small regression in #51 

We only secure comment posting, but comment reading is made available for everyone.

I used `withApiAuthRequired` inline, which is not ideal, but should be good enough. For us to use this wrapper in a conventional way, we’ll need to split the API route and change a few bits on the client. There is a chance that we’ll switch to a GraphQL API after transitioning frontend from Django, so I would not bother with API microoptimisations at this point.

---

We still have problems with `/auth/me`. I can look into them in a separate PR.