### PR TITLE
Replace `Comment` → `isPublished` with `status`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,27 +7,38 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum CommentStatus {
+  pending
+  approved
+  rejected
+}
+
 model Comment {
-  id          Int      @id @default(autoincrement())
-  accidentId  String   @map("accident_id") @db.VarChar
-  text        String
-  authorId    String   @map("author_id") @db.VarChar
-  isPublished Boolean  @default(false) @map("is_published")
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @default(now()) @map("updated_at")
-  author      User     @relation(fields: [authorId], references: [id])
+  id         Int    @id @default(autoincrement())
+  accidentId String @map("accident_id") @db.VarChar
+  text       String
+
+  authorId String @map("author_id") @db.VarChar
+  author   User   @relation(fields: [authorId], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @map("updated_at")
+
+  status CommentStatus @default(pending)
 
   @@map("comments")
 }
 
 model User {
-  id        String    @id @db.VarChar
-  name      String
-  email     String
-  picture   String?
-  createdAt DateTime  @default(now()) @map("created_at")
-  updatedAt DateTime  @default(now()) @map("updated_at")
-  comments  Comment[]
+  id      String  @id @db.VarChar
+  name    String
+  email   String
+  picture String?
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @map("updated_at")
+
+  comments Comment[]
 
   @@map("users")
 }

--- a/src/components/comment-item.tsx
+++ b/src/components/comment-item.tsx
@@ -66,7 +66,7 @@ export const CommentItem: React.VoidFunctionComponent<CommentItemProps> = ({
         <div>
           <CommentAuthor>{comment.authorName}</CommentAuthor>:{" "}
           <CommentDate>{formatDate(comment.createdAt)}</CommentDate>
-          {comment.isPublished ? undefined : (
+          {comment.status === "pending" ? undefined : (
             <Tag title="Комментарий еще не опубликован и виден только вам">
               На модерации
             </Tag>

--- a/src/pages/api/comments.ts
+++ b/src/pages/api/comments.ts
@@ -23,7 +23,7 @@ const commentSelect = {
   },
   createdAt: true,
   id: true,
-  isPublished: true,
+  status: true,
   text: true,
 } as const;
 
@@ -32,7 +32,7 @@ const convertSelectedCommentToPublicInfo = ({
   author,
   createdAt,
   id,
-  isPublished,
+  status,
   text,
 }: Prisma.CommentGetPayload<{
   select: typeof commentSelect;
@@ -42,7 +42,7 @@ const convertSelectedCommentToPublicInfo = ({
   authorName: author.name,
   createdAt: createdAt.toISOString(),
   id,
-  isPublished,
+  status,
   text,
 });
 
@@ -117,7 +117,7 @@ const handler: NextApiHandler = async (req, res) => {
       where: {
         OR: [
           {
-            isPublished: true,
+            status: "approved",
             accidentId,
           },
           ...(typeof myId === "string"
@@ -125,7 +125,8 @@ const handler: NextApiHandler = async (req, res) => {
                 {
                   accidentId,
                   authorId: myId,
-                },
+                  status: "pending",
+                } as const,
               ]
             : []),
         ],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { type CommentStatus } from "@prisma/client";
+
 export interface NewComment {
   text: string;
   accidentId: string;
@@ -9,7 +11,7 @@ export interface PublicCommentInfo {
   authorName: string;
   createdAt: string;
   id: number;
-  isPublished: boolean;
+  status: CommentStatus;
   text: string;
 }
 


### PR DESCRIPTION
⚠️ [Preview release](https://deploy-preview-61--dtp-stat-on-nextjs.netlify.app/iframes) won’t work yet because of breaking changes in Prisma schema. I was testing the changes locally:

```ini
## env.local
DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
```

```sh
docker run --publish 5432:5432 --env POSTGRES_PASSWORD=postgres --name dtp-stat-postgres --detach postgres 

yarn prisma db push
```

I will update the schema when this PR is reviewed. 

---

`isPublished` had two states (`true` and `false`). We now have three (`pending`, `approved` and `rejected`). This improve moderation process.