### PR TITLE
Show loading indicator in comments iframe

### DIFF
--- a/src/components/comment-input.tsx
+++ b/src/components/comment-input.tsx
@@ -36,20 +36,16 @@ const SubmitButtonContainer = styled.div`
 `;
 
 export const CommentInput: React.VoidFunctionComponent = () => {
-  const { setNewCommentText, newCommentText, comments, setComments } =
-    useComments();
+  const {
+    setNewCommentText,
+    newCommentText,
+    comments,
+    setComments,
+    commentsAreLoading,
+  } = useComments();
   const { user, isLoading: userIsLoading } = useUser();
   const { accidentId } = useAccident();
   const [submitting, setSubmitting] = React.useState<boolean>(false);
-
-  if (!user) {
-    return (
-      <div>
-        Для оставления комментария{" "}
-        <IframeAwareLoginLink>авторизуйтесь</IframeAwareLoginLink>.
-      </div>
-    );
-  }
 
   const handleSubmit = async () => {
     if (!newCommentText) {
@@ -78,8 +74,17 @@ export const CommentInput: React.VoidFunctionComponent = () => {
     setNewCommentText(event.target.value);
   };
 
-  if (userIsLoading) {
+  if (userIsLoading || commentsAreLoading) {
     return <></>;
+  }
+
+  if (!user) {
+    return (
+      <div>
+        Для оставления комментария{" "}
+        <IframeAwareLoginLink>авторизуйтесь</IframeAwareLoginLink>.
+      </div>
+    );
   }
 
   return (

--- a/src/components/comment-list.tsx
+++ b/src/components/comment-list.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import { useComments } from "../providers/comments-provider";
 import { CommentItem } from "./comment-item";
+import { Loader } from "./loader";
 
 const CommentsHeader = styled.h2`
   font-family: ${(props) => props.theme.fontFamily};
@@ -13,12 +14,21 @@ const CommentsHeader = styled.h2`
   color: #18334a;
 `;
 
+const StyledLoader = styled(Loader)`
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 0.5em;
+`;
+
 export const CommentList: React.VoidFunctionComponent = () => {
-  const { comments } = useComments();
+  const { comments, commentsAreLoading } = useComments();
 
   return (
     <div>
-      <CommentsHeader>Комментарии - {comments.length}</CommentsHeader>
+      <CommentsHeader>
+        Комментарии
+        {commentsAreLoading ? <StyledLoader /> : <> – {comments.length}</>}
+      </CommentsHeader>
       {comments.map((comment) => {
         return <CommentItem key={comment.id} comment={comment} />;
       })}

--- a/src/components/loader.tsx
+++ b/src/components/loader.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+
+// Source: https://codepen.io/aurer/pen/ZEJxpO (#8)
+
+export const Loader: React.VoidFunctionComponent<
+  React.SVGProps<SVGSVGElement>
+> = (props) => {
+  return (
+    <svg
+      version="1.1"
+      id="Layer_1"
+      xmlns="http://www.w3.org/2000/svg"
+      x="0px"
+      y="0px"
+      width="24px"
+      height="30px"
+      viewBox="0 0 24 30"
+      {...props}
+      xmlSpace="preserve"
+    >
+      <rect
+        x="0"
+        y="10"
+        width="4"
+        height="10"
+        fill="currentcolor"
+        opacity="0.2"
+      >
+        <animate
+          attributeName="opacity"
+          attributeType="XML"
+          values="0.2; 1; .2"
+          begin="0s"
+          dur="0.6s"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="height"
+          attributeType="XML"
+          values="10; 20; 10"
+          begin="0s"
+          dur="0.6s"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="y"
+          attributeType="XML"
+          values="10; 5; 10"
+          begin="0s"
+          dur="0.6s"
+          repeatCount="indefinite"
+        />
+      </rect>
+      <rect
+        x="8"
+        y="10"
+        width="4"
+        height="10"
+        fill="currentcolor"
+        opacity="0.2"
+      >
+        <animate
+          attributeName="opacity"
+          attributeType="XML"
+          values="0.2; 1; .2"
+          begin="0.15s"
+          dur="0.6s"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="height"
+          attributeType="XML"
+          values="10; 20; 10"
+          begin="0.15s"
+          dur="0.6s"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="y"
+          attributeType="XML"
+          values="10; 5; 10"
+          begin="0.15s"
+          dur="0.6s"
+          repeatCount="indefinite"
+        />
+      </rect>
+      <rect
+        x="16"
+        y="10"
+        width="4"
+        height="10"
+        fill="currentcolor"
+        opacity="0.2"
+      >
+        <animate
+          attributeName="opacity"
+          attributeType="XML"
+          values="0.2; 1; .2"
+          begin="0.3s"
+          dur="0.6s"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="height"
+          attributeType="XML"
+          values="10; 20; 10"
+          begin="0.3s"
+          dur="0.6s"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="y"
+          attributeType="XML"
+          values="10; 5; 10"
+          begin="0.3s"
+          dur="0.6s"
+          repeatCount="indefinite"
+        />
+      </rect>
+    </svg>
+  );
+};

--- a/src/components/loader.tsx
+++ b/src/components/loader.tsx
@@ -15,8 +15,8 @@ export const Loader: React.VoidFunctionComponent<
       width="24px"
       height="30px"
       viewBox="0 0 24 30"
-      {...props}
       xmlSpace="preserve"
+      {...props}
     >
       <rect
         x="0"


### PR DESCRIPTION
Closes #42 

**Demo** (with added five-second delay)

     <img src="https://user-images.githubusercontent.com/608862/152686840-df4fd7b2-26d7-4ce1-a4c4-fe8584d96440.gif" width=400 />
     
Comment input will not show _before_ both comments and user are loaded. This reduces UI flickering.

We can rewrite the logic with `<Suspense />` when React 18 is out.