### PR TITLE
Fix markup near `comment.status === "pending"`

### DIFF
--- a/src/components/comment-item.tsx
+++ b/src/components/comment-item.tsx
@@ -66,11 +66,11 @@ export const CommentItem: React.VoidFunctionComponent<CommentItemProps> = ({
         <div>
           <CommentAuthor>{comment.authorName}</CommentAuthor>:{" "}
           <CommentDate>{formatDate(comment.createdAt)}</CommentDate>
-          {comment.status === "pending" ? undefined : (
+          {comment.status === "pending" ? (
             <Tag title="Комментарий еще не опубликован и виден только вам">
               На модерации
             </Tag>
-          )}
+          ) : undefined}
         </div>
         <CommentText>
           <Linkify>{comment.text}</Linkify>


### PR DESCRIPTION
Follows #61, replaces `condition ? b : a` with `condition ? a : b`

**Before**

https://dtp-stat-on-nextjs.netlify.app/iframes/comments?accident-id=1

**After**

https://deploy-preview-64--dtp-stat-on-nextjs.netlify.app/iframes/comments?accident-id=1