### PR TITLE
Call `generateAvatarUrl` inside `AvatarImage`

### DIFF
--- a/src/components/avatar-image.tsx
+++ b/src/components/avatar-image.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 import styled from "styled-components";
 
+import { generateAvatarUrl } from "../shared/user-helpers";
+
 const defaultAvatarImgAttributes = {
   src: "",
   alt: "аватарка",
-  width: 28,
-  height: 28,
+  size: 28,
 };
 
 const StyledImg = styled.img`
@@ -14,23 +15,33 @@ const StyledImg = styled.img`
 `;
 
 interface AvatarImageProps {
-  src?: string | null;
+  /**
+   * Can be Auth0 user (i.e. ‘me’) or data from Prisma.
+   *
+   * If picture is missing but email is present, gravatar URL is generated
+   */
+  user: {
+    name?: string | null | undefined;
+    picture?: string | null | undefined;
+    email?: string | null | undefined;
+  };
+  /** With and height */
   size?: number;
-  alt?: string | null;
 }
 
 export const AvatarImage: React.VoidFunctionComponent<AvatarImageProps> = ({
-  src,
-  alt,
+  user,
   size,
 }) => {
+  const src = generateAvatarUrl(user.picture, user.email);
+
   return (
     <StyledImg
       referrerPolicy="no-referrer"
       src={src ?? defaultAvatarImgAttributes.src}
-      alt={alt ?? defaultAvatarImgAttributes.alt}
-      width={size || defaultAvatarImgAttributes.width}
-      height={size || defaultAvatarImgAttributes.height}
+      alt={user.name ?? defaultAvatarImgAttributes.alt}
+      width={size ?? defaultAvatarImgAttributes.size}
+      height={size ?? defaultAvatarImgAttributes.size}
     />
   );
 };

--- a/src/components/comment-input.tsx
+++ b/src/components/comment-input.tsx
@@ -6,7 +6,6 @@ import { useAccident } from "../providers/accident-provider";
 import { useComments } from "../providers/comments-provider";
 import { postComment } from "../requests/comments";
 import { IframeAwareLoginLink } from "../shared/django-helpers";
-import { generateAvatarUrl } from "../shared/user-helpers";
 import { NewComment } from "../types";
 import { AvatarImage } from "./avatar-image";
 import { Button } from "./button";
@@ -84,10 +83,7 @@ export const CommentInput: React.VoidFunctionComponent = () => {
 
   return (
     <InputContainer>
-      <AvatarImage
-        src={generateAvatarUrl(user.picture, user.email)}
-        alt={user.name}
-      />
+      <AvatarImage user={user} />
       <Textarea
         placeholder="Добавить комментарий..."
         disabled={submitting}

--- a/src/components/comment-item.tsx
+++ b/src/components/comment-item.tsx
@@ -61,7 +61,9 @@ export const CommentItem: React.VoidFunctionComponent<CommentItemProps> = ({
 }) => {
   return (
     <CommentContainer>
-      <AvatarImage src={comment.authorAvatarUrl} alt={comment.authorName} />
+      <AvatarImage
+        user={{ picture: comment.authorAvatarUrl, name: comment.authorName }}
+      />
       <div>
         <div>
           <CommentAuthor>{comment.authorName}</CommentAuthor>:{" "}

--- a/src/components/user-profile.tsx
+++ b/src/components/user-profile.tsx
@@ -2,7 +2,6 @@ import { useUser } from "@auth0/nextjs-auth0";
 import * as React from "react";
 
 import { IframeAwareLoginLink } from "../shared/django-helpers";
-import { generateAvatarUrl } from "../shared/user-helpers";
 import { AvatarImage } from "./avatar-image";
 import { Link } from "./link";
 
@@ -18,11 +17,7 @@ export const UserProfile: React.VoidFunctionComponent = () => {
 
   return user ? (
     <div>
-      <AvatarImage
-        src={generateAvatarUrl(user.picture, user.email)}
-        alt={user.name}
-        size={150}
-      />
+      <AvatarImage user={user} size={150} />
       <h4>{user.name}</h4>
       <p>{user.email}</p>
       <Link href="/api/auth/logout">Logout</Link>


### PR DESCRIPTION
We don’t convert Auth0 data from `useUser()` since #59. When `picture` is absent, we generate avatar URL with Gravatar. This implementation detail was ‘sticking out’ from `<AvatarImage />` in two places, so it was easy to forget it next time. I moved fallback gravatar generation into `<AvatarImage />` to avoid that.

Fallback gravatar URL is still produced server-side for comment authors. In that case, `<AvatarImage />` receives `picture` and `name`, but no `email`. Typings account for that.