### PR TITLE
Restore map icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react-linkify": "^1.0.0-alpha",
     "react-redux": "^7.2.6",
     "react-tooltip": "^4.2.21",
-    "react-yandex-maps": "^4.6.0",
     "sass": "^1.49.7",
     "scss": "^0.2.4",
     "sentry": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/react-dom": "^17.0.11",
     "@types/react-linkify": "^1.0.1",
     "@types/styled-components": "^5.1.22",
+    "@types/yandex-maps": "^2.1.20",
     "dotenv-flow": "^3.2.0",
     "eslint": "^8.8.0",
     "husky": "^7.0.4",

--- a/public/static/media/svg/circle-default.svg
+++ b/public/static/media/svg/circle-default.svg
@@ -1,3 +1,0 @@
-<svg height="10" width="10" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="5" cy="5" r="5" fill="rgba(24, 51, 74, 0.5)" />
-</svg>

--- a/src/components/inherited-map/models/map-store.ts
+++ b/src/components/inherited-map/models/map-store.ts
@@ -184,7 +184,7 @@ export const MapStore = types
       window.history.pushState(null, "", `?${currentParams.toString()}`);
     };
 
-    const createFeature = (acc: any, zoom: number) => ({
+    const createFeature = (acc: any) => ({
       type: "Feature",
       id: acc.id,
       geometry: {
@@ -224,8 +224,10 @@ export const MapStore = types
       heatmap.setData([]);
     };
 
-    const drawPoints = (accs: any[], zoom: number) => {
-      const data = accs.map((a) => createFeature(a, zoom));
+    const drawPoints = (accs: any[]) => {
+      objectManager.removeAll();
+      heatmap.setData([]);
+      const data = accs.map((a) => createFeature(a));
       objectManager.add(data);
 
       const params = new URLSearchParams(window.location.search);

--- a/src/components/inherited-map/models/map-store.ts
+++ b/src/components/inherited-map/models/map-store.ts
@@ -3,21 +3,14 @@ import ReactDOMServer from "react-dom/server";
 
 import { InfoBalloonContent } from "../components/info-balloon";
 import { Coordinate } from "../types";
-import { POINTS_ZOOM } from "../utils";
 import { RootStoreType } from "./root-store";
 
-// const supportedIconsBySeverity = {
-//   0: 'svg/circle-0.svg',
-//   1: 'svg/circle-1.svg',
-//   3: 'svg/circle-3.svg',
-//   4: 'svg/circle-4.svg',
-//   default: 'svg/circle-default.svg',
-// }
-
-const colorBySeverity = {
-  1: "#FFB81F",
-  3: "#FF7F24",
-  4: "#FF001A",
+const iconBySeverity = {
+  0: "/static/media/svg/circle-0.svg",
+  1: "/static/media/svg/circle-1.svg",
+  3: "/static/media/svg/circle-3.svg",
+  4: "/static/media/svg/circle-4.svg",
+  default: "/static/media/svg/circle-default.svg",
 };
 
 export const buildSelection = (filters: any[]) => {
@@ -195,8 +188,7 @@ export const MapStore = types
       type: "Feature",
       id: acc.id,
       geometry: {
-        type: "Circle",
-        radius: Math.max(120 - (zoom - POINTS_ZOOM) * 20, 10),
+        type: "Point",
         coordinates: [acc.point.latitude, acc.point.longitude],
       },
       properties: {
@@ -205,16 +197,13 @@ export const MapStore = types
         visible: true,
       },
       options: {
-        // iconLayout: 'default#image',
-        // // @ts-ignore
-        // iconImageHref: supportedIconsBySeverity[acc.severity],
-        iconImageSize: [5, 5],
-        // iconImageOffset: [-5, -5],
-
-        // preset: "islands#circleIcon",
-        // @ts-expect-error -- TODO: investigate
-        fillColor: colorBySeverity[acc.severity],
-        outline: false,
+        hideIconOnBalloonOpen: false,
+        iconImageHref:
+          iconBySeverity[acc.severity as "0" | "1" | "3" | "4"] ??
+          iconBySeverity.default,
+        iconImageOffset: [-5, -5],
+        iconImageSize: [10, 10],
+        iconLayout: "default#image",
       },
     });
 

--- a/src/components/inherited-map/models/map-store.ts
+++ b/src/components/inherited-map/models/map-store.ts
@@ -5,12 +5,20 @@ import { InfoBalloonContent } from "../components/info-balloon";
 import { Coordinate } from "../types";
 import { RootStoreType } from "./root-store";
 
+type Severity = "0" | "1" | "3" | "4";
+
 const iconBySeverity = {
   0: "/static/media/svg/circle-0.svg",
   1: "/static/media/svg/circle-1.svg",
   3: "/static/media/svg/circle-3.svg",
   4: "/static/media/svg/circle-4.svg",
-  default: "/static/media/svg/circle-default.svg",
+};
+
+const colorBySeverity = {
+  0: "rgba(24, 51, 74, 0.5)",
+  1: "#FFB81F",
+  3: "#FF7F24",
+  4: "#FF001A",
 };
 
 export const buildSelection = (filters: any[]) => {
@@ -69,20 +77,9 @@ export const MapStore = types
     function setMap(mapInstance: any) {
       map = mapInstance;
 
-      // @ts-expect-error -- TODO: add ymaps to window
       objectManager = new window.ymaps.ObjectManager({
-        clusterize: false,
-        gridSize: 256,
-        clusterIconPieChartRadius: (node: any) => {
-          // eslint-disable-next-line no-var
-          for (var radius = 0, i = 0, r = node.length; i < r; i++) {
-            radius += node[i].weight;
-          }
-          // return 10 + (10 * Math.log(radius)) / 0.69314718056 // PR
-          // return 25 + 2 * Math.floor(Math.log(radius)) // Yandex
-
-          return 15 + 4 * Math.floor(Math.log(radius));
-        },
+        clusterize: true,
+        groupByCoordinates: true,
         showInAlphabeticalOrder: true,
         clusterDisableClickZoom: true,
         clusterIconLayout: "default#pieChart",
@@ -113,18 +110,12 @@ export const MapStore = types
         handlerCloseBalloon();
       });
 
-      // @ts-expect-error -- TODO: add ymaps to window
+      // @ts-expect-error -- TODO: investigate why Heatmap is not in @types/yandex-map
       heatmap = new window.ymaps.Heatmap([], {
         radius: 15,
         dissipating: false,
         opacity: 0.5,
         intensityOfMidpoint: 0.5,
-        // gradient: {
-        //   0.1: 'rgba(128, 255, 0, 0.7)',
-        //   0.2: 'rgba(255, 255, 0, 0.8)',
-        //   0.7: 'rgba(234, 72, 58, 0.9)',
-        //   1.0: 'rgba(162, 36, 25, 1)',
-        // },
         gradient: {
           0: "rgba(126, 171, 85, 0.0)",
           0.2: "rgba(126, 171, 85, 0.6)",
@@ -199,11 +190,12 @@ export const MapStore = types
       options: {
         hideIconOnBalloonOpen: false,
         iconImageHref:
-          iconBySeverity[acc.severity as "0" | "1" | "3" | "4"] ??
-          iconBySeverity.default,
+          iconBySeverity[acc.severity as Severity] ?? iconBySeverity[0],
         iconImageOffset: [-5, -5],
         iconImageSize: [10, 10],
         iconLayout: "default#image",
+        iconColor:
+          colorBySeverity[acc.severity as Severity] ?? colorBySeverity[0],
       },
     });
 

--- a/src/components/inherited-map/models/root-store.ts
+++ b/src/components/inherited-map/models/root-store.ts
@@ -78,10 +78,7 @@ const RootStore = types
 
       if (self.mapStore.zoom >= POINTS_ZOOM) {
         self.mapStore.setFilter(prepareFilter());
-        self.mapStore.clearObjects();
-        window.requestAnimationFrame(() =>
-          self.mapStore.drawPoints(visibleAccs, self.mapStore.zoom),
-        );
+        self.mapStore.drawPoints(visibleAccs);
       } else {
         const accs = visibleAccs.filter(prepareFilter());
         self.mapStore.drawHeat(accs);
@@ -103,8 +100,7 @@ const RootStore = types
         loadArea();
         if (
           (zoom >= POINTS_ZOOM && prevZoom < POINTS_ZOOM) ||
-          (zoom < POINTS_ZOOM && prevZoom >= POINTS_ZOOM) ||
-          zoom !== prevZoom
+          (zoom < POINTS_ZOOM && prevZoom >= POINTS_ZOOM)
         ) {
           redraw();
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/yandex-maps@npm:^2.1.20":
+  version: 2.1.20
+  resolution: "@types/yandex-maps@npm:2.1.20"
+  checksum: ec47adee269ebefd9e5470a0aa1119b66530686d34f7c4f793cc74a6281d4e56c7d50b0c1be9efc2efac7576b210f120bf7ce9985be2c786530e85b5e2d9230c
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:^5.8.1":
   version: 5.10.2
   resolution: "@typescript-eslint/eslint-plugin@npm:5.10.2"
@@ -5562,6 +5569,7 @@ __metadata:
     "@types/react-dom": ^17.0.11
     "@types/react-linkify": ^1.0.1
     "@types/styled-components": ^5.1.22
+    "@types/yandex-maps": ^2.1.20
     date-fns: ^2.28.0
     dayjs: ^1.10.7
     dotenv-flow: ^3.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,19 +1801,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-react-context@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "create-react-context@npm:0.3.0"
-  dependencies:
-    gud: ^1.0.0
-    warning: ^4.0.3
-  peerDependencies:
-    prop-types: ^15.0.0
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0
-  checksum: e59b7a65671e59f5b11e06f67faadf0733ab6c33247d5631331aeb05450d180b8ae44d73817b9c02f1527654ba490ea3d3dd7320f8d6debb36776f10b0ae6a47
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^6.0.5":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
@@ -2979,13 +2966,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gud@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "gud@npm:1.0.0"
-  checksum: 3e2eb37cf794364077c18f036d6aa259c821c7fd188f2b7935cb00d589d82a41e0ebb1be809e1a93679417f62f1ad0513e745c3cf5329596e489aef8c5e5feae
-  languageName: node
-  linkType: hard
-
 "h3@npm:^0.2.10":
   version: 0.2.12
   resolution: "h3@npm:0.2.12"
@@ -3924,7 +3904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -5236,13 +5216,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-display-name@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "react-display-name@npm:0.2.5"
-  checksum: ba27778c975e09afea2bfb58c4052b9e12121329a5115391564085ec64293f2b54d3408b841ad04600142c37d40493442676bf1124d0cc0e68f2f1e02762812b
-  languageName: node
-  linkType: hard
-
 "react-dom@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-dom@npm:17.0.2"
@@ -5311,19 +5284,6 @@ __metadata:
     react: ">=16.0.0"
     react-dom: ">=16.0.0"
   checksum: dd145ae90768a8af5518672bfd91b985a57ff021b50a60044caedd872b457ea5134793cf8d5426bd45587fa6f722320936009f5c6533a4f94d665c0a23589222
-  languageName: node
-  linkType: hard
-
-"react-yandex-maps@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "react-yandex-maps@npm:4.6.0"
-  dependencies:
-    create-react-context: ^0.3.0
-    prop-types: ^15.7.2
-    react-display-name: ^0.2.5
-  peerDependencies:
-    react: ^0.14.9 || ^15.x || ^16.x || ^17.x
-  checksum: 3715e75e5156391e71eda383d05e5dfc9327a3523e5ea54e392b87a054add335d647d9e9aa0a63c7e37b4b78c93022d0020ffdebdc4354a793767252932d26e8
   languageName: node
   linkType: hard
 
@@ -5626,7 +5586,6 @@ __metadata:
     react-linkify: ^1.0.0-alpha
     react-redux: ^7.2.6
     react-tooltip: ^4.2.21
-    react-yandex-maps: ^4.6.0
     sass: ^1.49.7
     scss: ^0.2.4
     sentry: ^0.1.2
@@ -6703,15 +6662,6 @@ __metadata:
   version: 3.0.3
   resolution: "vscode-uri@npm:3.0.3"
   checksum: 683bf9de835c3cef0b51c104a4949bf746148ded7c2287ebafcc506d20aa0e90b99385a972dba8132903420dba67fc33a5e146e30212c4a6b3ca5d74d1f95702
-  languageName: node
-  linkType: hard
-
-"warning@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "warning@npm:4.0.3"
-  dependencies:
-    loose-envify: ^1.0.0
-  checksum: 4f2cb6a9575e4faf71ddad9ad1ae7a00d0a75d24521c193fa464f30e6b04027bd97aa5d9546b0e13d3a150ab402eda216d59c1d0f2d6ca60124d96cd40dfa35c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #76, closes #77

Out of scope (to be explored after initial release):
- clusters for accidents that don’t share coordinates (#79)
- performance (drawing points is still as slow as in the current version of [dtp-stat.ru](https://dtp-stat.ru))

Preview: https://deploy-preview-81--dtp-stat-on-nextjs.netlify.app/iframes/map

---

<img width="1108" alt="Screenshot 2022-02-13 at 15 05 21" src="https://user-images.githubusercontent.com/608862/153759620-a662c0cf-f812-4844-9e16-1f240a1717dc.png">

<img width="1107" alt="Screenshot 2022-02-13 at 15 08 06" src="https://user-images.githubusercontent.com/608862/153759618-c7156ebc-4a8e-487e-bb1f-eaa7e9e05052.png">

