### PR TITLE
Re-enable `@typescript-eslint/no-unused-vars` in `inherited-map`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,7 +26,6 @@ module.exports = {
         "@typescript-eslint/no-unsafe-call": "off",
         "@typescript-eslint/no-unsafe-member-access": "off",
         "@typescript-eslint/no-unsafe-return": "off",
-        "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/restrict-plus-operands": "off",
         "@typescript-eslint/restrict-template-expressions": "off",

--- a/src/components/inherited-map/components/filter-panel/category-header.js
+++ b/src/components/inherited-map/components/filter-panel/category-header.js
@@ -8,7 +8,7 @@ const CategoryHeader = () => {
   const filter = filterStore.filters.find(
     (f) => f.key === filterStore.currentKey,
   );
-  const handleBack = (e) => {
+  const handleBack = () => {
     filterStore.setCurrentKey(null);
     filterStore.setSearch("");
   };

--- a/src/components/inherited-map/components/filter-panel/date-filter.js
+++ b/src/components/inherited-map/components/filter-panel/date-filter.js
@@ -63,7 +63,7 @@ const DateFilterSection = ({ filter }) => {
     setText(e.target.value);
     dirtyRef.current = true;
   };
-  const handleBlur = (e) => {
+  const handleBlur = () => {
     if (dirtyRef.current) {
       setText(null);
       setError(null);
@@ -87,7 +87,7 @@ const DateFilterSection = ({ filter }) => {
           />
         </div>
         <div className="date-dropdown">
-          <button className="date-button" onClick={(e) => setShow(true)}>
+          <button className="date-button" onClick={() => setShow(true)}>
             <svg className="icon icon-down">
               <use xlinkHref="/static/media/svg/sprite.svg#arrow-down" />
             </svg>
@@ -120,7 +120,7 @@ const DateMenu = ({ handleClick, setShow }) => {
         <div
           key={r.label}
           className="date-value"
-          onClick={(e) => handleClick(r)}
+          onClick={() => handleClick(r)}
         >
           {r.label}
         </div>

--- a/src/components/inherited-map/components/filter-panel/date-filter.js
+++ b/src/components/inherited-map/components/filter-panel/date-filter.js
@@ -87,7 +87,12 @@ const DateFilterSection = ({ filter }) => {
           />
         </div>
         <div className="date-dropdown">
-          <button className="date-button" onClick={() => setShow(true)}>
+          <button
+            className="date-button"
+            onClick={() => {
+              setShow(true);
+            }}
+          >
             <svg className="icon icon-down">
               <use xlinkHref="/static/media/svg/sprite.svg#arrow-down" />
             </svg>
@@ -120,7 +125,9 @@ const DateMenu = ({ handleClick, setShow }) => {
         <div
           key={r.label}
           className="date-value"
-          onClick={() => handleClick(r)}
+          onClick={() => {
+            handleClick(r);
+          }}
         >
           {r.label}
         </div>

--- a/src/components/inherited-map/components/filter-panel/filter-panel-category.js
+++ b/src/components/inherited-map/components/filter-panel/filter-panel-category.js
@@ -9,7 +9,9 @@ const CategoryValue = observer(({ value }) => (
     <input
       type="checkbox"
       checked={value.selected}
-      onChange={() => value.toggle()}
+      onChange={() => {
+        value.toggle();
+      }}
     />
     <span className="checkmark">
       <svg className="icon icon-check">

--- a/src/components/inherited-map/components/filter-panel/filter-panel-category.js
+++ b/src/components/inherited-map/components/filter-panel/filter-panel-category.js
@@ -9,7 +9,7 @@ const CategoryValue = observer(({ value }) => (
     <input
       type="checkbox"
       checked={value.selected}
-      onChange={(e) => value.toggle()}
+      onChange={() => value.toggle()}
     />
     <span className="checkmark">
       <svg className="icon icon-check">

--- a/src/components/inherited-map/components/filter-panel/filter-panel-hidden.js
+++ b/src/components/inherited-map/components/filter-panel/filter-panel-hidden.js
@@ -29,7 +29,9 @@ export const FilterPanelHidden = observer(() => {
       </div>
       <button
         className="btn-hideFilter"
-        onClick={(e) => filterStore.setVisible(true)}
+        onClick={() => {
+          filterStore.setVisible(true);
+        }}
       >
         <svg className="icon icon-arrow-up">
           <use xlinkHref="/static/media/svg/sprite.svg#arrow-down" />

--- a/src/components/inherited-map/components/filter-panel/filter-panel-normal.js
+++ b/src/components/inherited-map/components/filter-panel/filter-panel-normal.js
@@ -26,10 +26,20 @@ const CategoryTag = observer(({ filter }) => {
   if (filter.values.some((v) => v.selected)) {
     return (
       <div className="category-tag active">
-        <button className="btn-rect" onClick={(e) => filter.navigate()}>
+        <button
+          className="btn-rect"
+          onClick={() => {
+            filter.navigate();
+          }}
+        >
           <span>{filter.label}</span>
         </button>
-        <button className="btn-decline" onClick={(e) => filter.reset()}>
+        <button
+          className="btn-decline"
+          onClick={() => {
+            filter.reset();
+          }}
+        >
           <svg className="icon icon-decline">
             <use xlinkHref="/static/media/svg/sprite.svg#decline" />
           </svg>
@@ -40,7 +50,12 @@ const CategoryTag = observer(({ filter }) => {
 
   return (
     <div className="category-tag">
-      <button className="btn-rect" onClick={(e) => filter.navigate()}>
+      <button
+        className="btn-rect"
+        onClick={() => {
+          filter.navigate();
+        }}
+      >
         <span>{filter.label}</span>
       </button>
     </div>
@@ -74,7 +89,9 @@ export const FilterPanelNormal = observer(() => {
       </div>
       <button
         className="btn-hideFilter"
-        onClick={(e) => filterStore.setVisible(false)}
+        onClick={() => {
+          filterStore.setVisible(false);
+        }}
       >
         <svg className="icon icon-arrow-up">
           <use xlinkHref="/static/media/svg/sprite.svg#arrow-up" />

--- a/src/components/inherited-map/components/filter-panel/region-filter.tsx
+++ b/src/components/inherited-map/components/filter-panel/region-filter.tsx
@@ -1,7 +1,9 @@
 import { observer } from "mobx-react";
 import * as React from "react";
 
-const RegionFilterSection = ({ values }) => (
+const RegionFilterSection: React.VoidFunctionComponent<{
+  value: unknown;
+}> = () => (
   <div className="category-item__draw" tabIndex={0}>
     <svg className="icon icon-edit">
       <use xlinkHref="/static/media/svg/sprite.svg#edit" />

--- a/src/components/inherited-map/components/map/map.js
+++ b/src/components/inherited-map/components/map/map.js
@@ -80,7 +80,7 @@ export const Map = observer(() => {
           .options.set("position", { top: top + 206 + 16, right: 20 });
       };
       updatePos(mapRef.current.offsetHeight);
-      map.events.add("sizechange", (e) => {
+      map.events.add("sizechange", () => {
         updatePos(mapRef.current.offsetHeight);
       });
     });

--- a/src/components/inherited-map/models/map-store.ts
+++ b/src/components/inherited-map/models/map-store.ts
@@ -181,7 +181,7 @@ export const MapStore = types
       geometry: {
         type: "Circle",
         radius:
-          calculateMetersPerPixelInWgs84(acc.point.latitude, self.zoom) *
+          calculateMetersPerPixelInWgs84(acc.point.latitude, zoom) *
           pointRadiusInPixels,
         coordinates: [acc.point.latitude, acc.point.longitude],
       },


### PR DESCRIPTION
We disabled a few ESLint rules in `src/components/inherited-map/**` when porting the map (#31). This change starts a series of small PRs where these rules are re-enabled.

The result should be unchanged: https://deploy-preview-84--dtp-stat-on-nextjs.netlify.app/iframes/map