### PR TITLE
Implement tunnelling for Sentry requests

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -7,4 +7,5 @@ Sentry.init({
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? "unset",
   dsn,
   tracesSampleRate: 1,
+  tunnel: "/api/sentry-tunnel",
 });

--- a/src/pages/api/sentry-tunnel.ts
+++ b/src/pages/api/sentry-tunnel.ts
@@ -22,17 +22,12 @@ const handler: NextApiHandler = async (req, res) => {
     }
 
     const { host, pathname: projectId } = new URL(requestDsn);
-
-    const url = `https://${host}/api/${projectId}/envelope/`;
-    const response = await fetch(url, {
-      method: "POST",
-      body,
-    });
+    const targetUrl = `https://${host}/api/${projectId}/envelope/`;
+    const response = await fetch(targetUrl, { method: "POST", body });
 
     return response.json();
   } catch (error) {
     captureException(error);
-
     res.status(400).json({ status: "invalid request" });
 
     return;

--- a/src/pages/api/sentry-tunnel.ts
+++ b/src/pages/api/sentry-tunnel.ts
@@ -21,16 +21,15 @@ const handler: NextApiHandler = async (req, res) => {
       throw new Error(`Invalid DSN: ${requestDsn!}`);
     }
 
-    const { host, pathname: projectId } = new URL(requestDsn);
+    const { host, pathname } = new URL(requestDsn);
+    const projectId = pathname.replace(/^\//, "");
     const targetUrl = `https://${host}/api/${projectId}/envelope/`;
     const response = await fetch(targetUrl, { method: "POST", body });
 
-    return response.json();
+    res.json(response.json());
   } catch (error) {
     captureException(error);
     res.status(400).json({ status: "invalid request" });
-
-    return;
   }
 };
 

--- a/src/pages/api/sentry-tunnel.ts
+++ b/src/pages/api/sentry-tunnel.ts
@@ -1,0 +1,42 @@
+// Inspired by: https://docs.sentry.io/platforms/javascript/troubleshooting/#dealing-with-ad-blockers
+
+import { captureException, withSentry } from "@sentry/nextjs";
+import { NextApiHandler } from "next";
+
+const handler: NextApiHandler = async (req, res) => {
+  const projectDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!projectDsn) {
+    throw new Error("Sentry is currently disabled (DSN not set)");
+  }
+
+  try {
+    const body = req.body as string;
+    const pieces = body.split("\n");
+
+    // @todo Implement runtime check instead of type casting
+    const header = JSON.parse(pieces[0] ?? "") as Record<string, string>;
+    const requestDsn = header["dsn"];
+
+    if (projectDsn !== requestDsn) {
+      throw new Error(`Invalid DSN: ${requestDsn!}`);
+    }
+
+    const { host, pathname: projectId } = new URL(requestDsn);
+
+    const url = `https://${host}/api/${projectId}/envelope/`;
+    const response = await fetch(url, {
+      method: "POST",
+      body,
+    });
+
+    return response.json();
+  } catch (error) {
+    captureException(error);
+
+    res.status(400).json({ status: "invalid request" });
+
+    return;
+  }
+};
+
+export default withSentry(handler);


### PR DESCRIPTION
Closes: https://github.com/dtpstat/website/issues/83

Docs: https://docs.sentry.io/platforms/javascript/troubleshooting/#dealing-with-ad-blockers

Preview: https://deploy-preview-87--dtp-stat-on-nextjs.netlify.app/iframes

I blocked Yandex maps in devtools and successfully received a new error report in Sentry UI

<img width="557" alt="Screenshot 2022-02-16 at 23 29 49" src="https://user-images.githubusercontent.com/608862/154375082-4b00b5ea-e458-4692-91a4-8564b6ae31b4.png">

 

<img width="634" alt="Screenshot 2022-02-16 at 23 31 44" src="https://user-images.githubusercontent.com/608862/154375173-dacfc843-8a62-4469-9fb0-8a89bcf9f70f.png">

  

<img width="853" alt="Screenshot 2022-02-16 at 23 29 15" src="https://user-images.githubusercontent.com/608862/154375209-9226fc40-5e25-4f56-b02e-9edafc1f1f33.png">