### PR TITLE
Фикс точности геолокации

### DIFF
--- a/src/components/inherited-map/components/layers/location-button.tsx
+++ b/src/components/inherited-map/components/layers/location-button.tsx
@@ -24,7 +24,6 @@ export const LocationButton = observer<
     try {
       // @ts-expect-error -- geolocation is not included into Yandex Maps typings
       const result = await window.ymaps.geolocation.get({
-        provider: "yandex",
         mapStateAutoApply: true,
       });
       await map?.panTo(result.geoObjects.position);


### PR DESCRIPTION
Провайдер геолокации. Допустимые значения: `'yandex'` - геолокация по данным Яндекса на основе ip пользователя, `'browser'` - встроенная браузерная геолокация, `'auto'` - провести геолокацию всеми доступными способами и выбрать лучшее значение. Значение по умолчанию: `'auto'`